### PR TITLE
Implementation of the hash interface for TLSH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,16 @@ benchcmp:
 	git stash save "stashing for benchcmp"
 	@go test -test.benchmem=true -run=NONE -bench=. ./... > bench_head.test
 	git stash pop
-	benchcmp bench_head.test bench_current.test
+	benchstat bench_head.test bench_current.test
+
+.PHONY: benchbcmp
+benchbcmp:
+	# ensure no govenor weirdness
+	# sudo cpufreq-set -g performance
+	go test -test.benchmem=true -run=NONE -bench=. ./... > bench_current.test
+	git stash save "stashing for benchcmp"
+	git checkout main
+	@go test -test.benchmem=true -run=NONE -bench=. ./... > bench_main.test
+	git checkout -
+	git stash pop
+	benchstat bench_main.test bench_current.test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Workflow](https://github.com/glaslos/ssdeep/actions/workflows/go.yml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/glaslos/tlsh)](https://goreportcard.com/report/github.com/glaslos/tlsh)
-[![Go Reference](https://pkg.go.dev/badge/badge/glaslos/tlsh.svg)](https://pkg.go.dev/badge/glaslos/tlsh)
+[![Go Reference](https://pkg.go.dev/badge/badge/glaslos/tlsh.svg)](https://pkg.go.dev/github.com/glaslos/tlsh)
 
 # TLSH
 Trend Micro Locality Sensitive Hash lib in Golang

--- a/distance.go
+++ b/distance.go
@@ -25,7 +25,8 @@ func digestDistance(x [codeSize]byte, y [codeSize]byte) (diff int) {
 }
 
 // diffTotal calculates diff between two Tlsh hashes for hash header and body.
-func diffTotal(a, b *Tlsh, lenDiff bool) (diff int) {
+func diffTotal(a, b *TLSH, lenDiff bool) int {
+	diff := 0
 	if lenDiff {
 		lDiff := modDiff(a.lValue, b.lValue, 256)
 

--- a/hash.go
+++ b/hash.go
@@ -50,9 +50,7 @@ func (t *TLSH) Sum(b []byte) []byte {
 
 	biHash := bucketsBinaryRepresentation(t.state.buckets, q1, q2, q3)
 
-	h := New(t.state.checksum, lValue(t.state.fileSize), q1Ratio, q2Ratio, qRatio, biHash)
-	h.state = t.state
-	*t = *h
+	*t = *new(t.state.checksum, lValue(t.state.fileSize), q1Ratio, q2Ratio, qRatio, biHash, t.state)
 	return t.Binary()
 }
 

--- a/hash.go
+++ b/hash.go
@@ -1,0 +1,108 @@
+package tlsh
+
+import (
+	"hash"
+)
+
+var salt = [6]byte{2, 3, 5, 7, 11, 13}
+
+type chunkState struct {
+	buckets    [numBuckets]uint
+	chunk      [windowLength]byte
+	chunkSlice []byte
+	fileSize   int
+	checksum   byte
+	chunk3     *[3]byte
+}
+
+var _ hash.Hash = &TLSH{}
+
+func (t *TLSH) Reset() {
+	t.checksum = byte(0)
+	t.lValue = 0
+	t.q1Ratio = 0
+	t.q2Ratio = 0
+	t.qRatio = 0
+	t.code = [codeSize]byte{}
+	t.state = chunkState{
+		buckets:    [numBuckets]uint{},
+		chunk:      [windowLength]byte{},
+		chunkSlice: []byte{},
+		fileSize:   0,
+		checksum:   byte(0),
+		chunk3:     &[3]byte{},
+	}
+}
+
+func (t *TLSH) BlockSize() int {
+	return 1
+}
+
+func (t *TLSH) Size() int {
+	return len(t.Binary())
+}
+
+func (t *TLSH) Sum(b []byte) []byte {
+	q1, q2, q3 := quartilePoints(t.state.buckets)
+	q1Ratio := byte(float32(q1)*100/float32(q3)) % 16
+	q2Ratio := byte(float32(q2)*100/float32(q3)) % 16
+	qRatio := ((q1Ratio & 0xF) << 4) | (q2Ratio & 0xF)
+
+	biHash := bucketsBinaryRepresentation(t.state.buckets, q1, q2, q3)
+
+	h := New(t.state.checksum, lValue(t.state.fileSize), q1Ratio, q2Ratio, qRatio, biHash)
+	h.state = t.state
+	*t = *h
+	return t.Binary()
+}
+
+func (s *chunkState) process() {
+	s.chunk3[0] = s.chunk[0]
+	s.chunk3[1] = s.chunk[1]
+	s.chunk3[2] = s.checksum
+	s.checksum = pearsonHash(0, s.chunk3)
+
+	s.chunk3[2] = s.chunk[2]
+	s.buckets[pearsonHash(salt[0], s.chunk3)]++
+
+	s.chunk3[2] = s.chunk[3]
+	s.buckets[pearsonHash(salt[1], s.chunk3)]++
+
+	s.chunk3[1] = s.chunk[2]
+	s.buckets[pearsonHash(salt[2], s.chunk3)]++
+
+	s.chunk3[2] = s.chunk[4]
+	s.buckets[pearsonHash(salt[3], s.chunk3)]++
+
+	s.chunk3[1] = s.chunk[1]
+	s.buckets[pearsonHash(salt[4], s.chunk3)]++
+
+	s.chunk3[1] = s.chunk[3]
+	s.buckets[pearsonHash(salt[5], s.chunk3)]++
+
+	copy(s.chunk[1:], s.chunk[0:4])
+}
+
+func (t *TLSH) Write(p []byte) (int, error) {
+	t.state.fileSize += len(p)
+	if len(t.state.chunkSlice) < windowLength {
+		missing := windowLength - len(t.state.chunkSlice)
+		switch {
+		case len(p) < missing:
+			t.state.chunkSlice = append(t.state.chunkSlice, p...)
+			return len(p), nil
+		default:
+			t.state.chunkSlice = append(t.state.chunkSlice, p[0:missing]...)
+			p = p[missing:]
+			copy(t.state.chunk[:], t.state.chunkSlice[0:5])
+			t.state.chunk = reverse(t.state.chunk)
+			t.state.process()
+		}
+	}
+	for _, b := range p {
+		t.state.chunk[0] = b
+		t.state.process()
+	}
+
+	return len(p), nil
+}

--- a/hash_test.go
+++ b/hash_test.go
@@ -7,11 +7,7 @@ import (
 )
 
 func TestHashinterface(t *testing.T) {
-	h := &TLSH{
-		state: chunkState{
-			checksum: byte(0),
-		},
-	}
+	h := New()
 	var _ hash.Hash = h
 	t.Log(h.BlockSize())
 	h.Reset()
@@ -27,28 +23,20 @@ func TestHashinterface(t *testing.T) {
 }
 
 func TestHashWrite(t *testing.T) {
-	h1 := &TLSH{
-		state: chunkState{
-			buckets:    [numBuckets]uint{},
-			chunk:      [windowLength]byte{},
-			chunkSlice: []byte{},
-			fileSize:   0,
-			checksum:   byte(0),
-			chunk3:     &[3]byte{},
-		},
-	}
+	// hash using the hash.Hash interface methods
+	h1 := New()
 	h1.Write([]byte("1234"))
 	h1.Write([]byte("11"))
 	h1.Write([]byte("1111111"))
 	t.Log(fmt.Sprintf("h1: %x", h1.Sum(nil)))
-	t.Logf("checksum h1: %d, %d", h1.state.checksum, h1.checksum)
+	t.Logf("checksum h1: %d, %x", h1.state.checksum, h1.checksum)
 
 	// hash from read
 	h2, err := HashBytes([]byte("1234111111111"))
 	if err != nil {
 		t.Error(err)
 	}
-	t.Logf("checksum h2: %d, %d", h2.state.checksum, h2.checksum)
+	t.Logf("checksum h2: %d, %x", h2.state.checksum, h2.checksum)
 	t.Log(fmt.Sprintf("h2: %x", h2.Binary()))
 
 	// compare hashes

--- a/hash_test.go
+++ b/hash_test.go
@@ -1,0 +1,65 @@
+package tlsh
+
+import (
+	"fmt"
+	"hash"
+	"testing"
+)
+
+func TestHashinterface(t *testing.T) {
+	h := &TLSH{
+		state: chunkState{
+			checksum: byte(0),
+		},
+	}
+	var _ hash.Hash = h
+	t.Log(h.BlockSize())
+	h.Reset()
+	n, err := h.Write([]byte("hello"))
+	if err != nil {
+		t.Error(err)
+	}
+	t.Log(n)
+	t.Log(h.Size())
+	hash := h.Sum(nil)
+	t.Log(hash)
+	t.Log(fmt.Sprintf("%x", hash[:]))
+}
+
+func TestHashWrite(t *testing.T) {
+	h1 := &TLSH{
+		state: chunkState{
+			buckets:    [numBuckets]uint{},
+			chunk:      [windowLength]byte{},
+			chunkSlice: []byte{},
+			fileSize:   0,
+			checksum:   byte(0),
+			chunk3:     &[3]byte{},
+		},
+	}
+	h1.Write([]byte("1234"))
+	h1.Write([]byte("11"))
+	h1.Write([]byte("1111111"))
+	t.Log(fmt.Sprintf("h1: %x", h1.Sum(nil)))
+	t.Logf("checksum h1: %d, %d", h1.state.checksum, h1.checksum)
+
+	// hash from read
+	h2, err := HashBytes([]byte("1234111111111"))
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("checksum h2: %d, %d", h2.state.checksum, h2.checksum)
+	t.Log(fmt.Sprintf("h2: %x", h2.Binary()))
+
+	// compare hashes
+	if h1.state.fileSize != h2.state.fileSize {
+		t.Errorf("file size mismatch: %d != %d", h1.state.fileSize, h2.state.fileSize)
+	}
+	if h1.checksum != h2.checksum {
+		t.Errorf("checksum mismatch: %x != %x", h1.checksum, h2.checksum)
+	}
+	diff := h1.Diff(h2)
+	if diff != 0 {
+		t.Errorf("hashes differ by: %d", diff)
+	}
+}


### PR DESCRIPTION
Following the suggestion in #24 I've implemented the [hash.Hash](https://pkg.go.dev/hash#Hash) interface for TLSH.
~Currently I've duplicated a bunch of code which should be deduplicated but I wanted to compare apples with apples.~
I have not done any optimizations.